### PR TITLE
fix: always use IPv4

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -94,6 +94,7 @@ module.exports = exports = (countryCode, vatNumber, timeout, callback) ->
     method: 'POST',
     path: parsedUrl.path
     headers: headers
+    family: 4
 
   req = http.request options, (res) ->
     res.setEncoding 'utf8'


### PR DESCRIPTION
There's something weird where the SOAP service never responds to IPv6 requests (which my machine seems to default to), so this small change fixes it.