### PR TITLE
Update index.coffee

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -51,7 +51,7 @@ getReadableErrorMsg = (faultstring) ->
 # I don't really want to install any xml parser which may require multpiple packages
 parseSoapResponse = (soapMessage) ->
   parseField = (field) ->
-    regex = new RegExp "<#{field}>\((\.|\\s)\*\)</#{field}>", 'gm'
+    regex = new RegExp "<#{field}>\((\.|\\s)\*?\)</#{field}>", 'gm'
     match = regex.exec(soapMessage)
     if !match
       err = new Error "Failed to parseField #{field}"


### PR DESCRIPTION
Fixed regex backtracking error when the regex engine encounters long strings of white space.

Sample Problematic input/VIES Soap Response:
`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><checkVatResponse xmlns="urn:ec.europa.eu:taxud:vies:services:checkVat:types"><countryCode>LU</countryCode><vatNumber>1234</vatNumber><requestDate>2017-12-28+01:00</requestDate><valid>true</valid><name>PROBLEM                               NAME</name><address>Test ADDRESS</address></checkVatResponse></soap:Body></soap:Envelope>`

