### PR TITLE
Using https in requests.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,7 +1,7 @@
 url = require 'url'
-http = require 'http'
+https = require 'https'
 
-serviceUrl = 'http://ec.europa.eu/taxation_customs/vies/services/checkVatService'
+serviceUrl = 'https://ec.europa.eu/taxation_customs/vies/services/checkVatService'
 
 parsedUrl = url.parse serviceUrl
 
@@ -97,7 +97,7 @@ module.exports = exports = (countryCode, vatNumber, timeout, callback) ->
     headers: headers
     family: 4
 
-  req = http.request options, (res) ->
+  req = https.request options, (res) ->
     res.setEncoding 'utf8'
     str = ''
     res.on 'data', (chunk) ->


### PR DESCRIPTION
We recently experienced errors while querying the VIES service, with a stack trace similar to the following:
```
Error: Failed to parseField countryCode
    at parseField (src/node_modules/validate-vat/lib/index.js:53:15)
    at parseSoapResponse (src/node_modules/validate-vat/lib/index.js:67:22)
    at IncomingMessage.<anonymous> (src/node_modules/validate-vat/lib/index.js:108:18)
    at IncomingMessage.emit (events.js:215:7)
    at endReadableNT (_stream_readable.js:1183:12)
    at processTicksAndRejections (internal/process/task_queues.js:80:21) {
  soapMessage: '<HTML><HEAD>\r\n' +
    '<TITLE>Redirect</TITLE>\r\n' +
    '</HEAD>\r\n' +
    '<BODY>\r\n' +
    '<FONT face="Helvetica">\r\n' +
    '<big><strong></strong></big><BR>\r\n' +
    '</FONT>\r\n' +
    '<blockquote>\r\n' +
    '<TABLE border=0 cellPadding=1 width="80%">\r\n' +
    '<TR><TD>\r\n' +
    '<FONT face="Helvetica">\r\n' +
    '<big>Redirect (policy_request_redirect)</big>\r\n' +
    '<BR>\r\n' +
    '<BR>\r\n' +
    '</FONT>\r\n' +
    '</TD></TR>\r\n' +
    '<TR><TD>\r\n' +
    '<FONT face="Helvetica">\r\n' +
    'Click <a href="https:&#x2F;&#x2F;ec.europa.eu&#x2F;taxation_customs&#x2F;vies&#x2F;services&#x2F;checkVatService">here</a> if you are not automatically redirected.\r\n' +
    '</FONT>\r\n' +
    '</TD></TR>\r\n' +
    '<TR><TD>\r\n' +
    '<FONT face="Helvetica">\r\n' +
    '\r\n' +
    '</FONT>\r\n' +
    '</TD></TR>\r\n' +
    '<TR><TD>\r\n' +
    '<FONT face="Helvetica" SIZE=2>\r\n' +
    '<BR>\r\n' +
    'For assistance, contact your network support team.\r\n' +
    '</FONT>\r\n' +
    '</TD></TR>\r\n' +
    '</TABLE>\r\n' +
    '</blockquote>\r\n' +
    '</FONT>\r\n' +
    '</BODY></HTML>\r\n'
}
```
Careful investigation of the above payload shows that it indicates a redirect to the same URL, however with `https` protocol (instead of `http`): our assumption is that VIES recently started enforcing encryption by default.

`validate-vat` will not follow the redirect automatically, and the resulting payload is therefore unparseable. Since `https` is nowadays ubiquitous on all respectable systems, we believe it is safe to use it by default.

This PR simply changes the necessary URLs and switches to the `https` module for handling them. It has been tested with "real world" data and seems to work well.

We appreciate your attention.